### PR TITLE
MP-2428 - Integrate QR code scanner and layout preview

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,9 +75,11 @@ dependencies {
     implementation Libs.Retrofit.retrofit
     implementation Libs.okhttp
     implementation Libs.coil
+    implementation Libs.zxing
 
     // Compose
     implementation Libs.AndroidX.Compose.material
+    implementation Libs.AndroidX.Compose.material3
     implementation Libs.AndroidX.Activity.activityCompose
     implementation Libs.AndroidX.Compose.foundation
     implementation Libs.AndroidX.Compose.layout

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,16 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA"/>
 
     <application
         android:name=".RoktDemoApplication"
         android:allowBackup="true"
+        android:hardwareAccelerated="true"
         android:icon="@mipmap/android"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:usesCleartextTraffic="true"
-        android:theme="@style/Theme.RoktDemoSplash">
-        <activity android:name=".MainActivity"
+        android:theme="@style/Theme.RoktDemoSplash"
+        android:usesCleartextTraffic="true">
+        <activity
+            android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/rokt/roktdemo/ui/NavGraph.kt
+++ b/app/src/main/java/com/rokt/roktdemo/ui/NavGraph.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavController
 object MainDestinations {
     const val HOME = "home"
     const val DEMO = "demo"
+    const val LAYOUTS = "layouts"
     const val ABOUT_ROKT = "about"
 }
 
@@ -18,6 +19,10 @@ object MainDestinations {
 class MainActions constructor(navController: NavController) {
     val demoLibraryClicked: () -> Unit = {
         navController.navigate(MainDestinations.DEMO)
+    }
+
+    val demoLayoutsClicked: () -> Unit = {
+        navController.navigate(MainDestinations.LAYOUTS)
     }
 
     val aboutRoktClicked: () -> Unit = {

--- a/app/src/main/java/com/rokt/roktdemo/ui/RoktDemoApp.kt
+++ b/app/src/main/java/com/rokt/roktdemo/ui/RoktDemoApp.kt
@@ -11,6 +11,7 @@ import com.rokt.roktdemo.MainActivityViewModel
 import com.rokt.roktdemo.ui.about.AboutPage
 import com.rokt.roktdemo.ui.demo.DemoPage
 import com.rokt.roktdemo.ui.home.HomePage
+import com.rokt.roktdemo.ui.layouts.DemoLayoutsPage
 import com.rokt.roktdemo.ui.theme.RoktColors.LightColors
 
 @Composable
@@ -27,6 +28,10 @@ fun RoktDemoApp(viewModel: MainActivityViewModel) {
 
                 composable(MainDestinations.DEMO) {
                     DemoPage(actions.backPressed, viewModel)
+                }
+
+                composable(MainDestinations.LAYOUTS) {
+                    DemoLayoutsPage(actions.backPressed, viewModel)
                 }
 
                 composable(MainDestinations.ABOUT_ROKT) {

--- a/app/src/main/java/com/rokt/roktdemo/ui/common/Buttons.kt
+++ b/app/src/main/java/com/rokt/roktdemo/ui/common/Buttons.kt
@@ -44,11 +44,13 @@ fun ButtonDark(text: String, onClick: () -> Unit) {
 }
 
 @Composable
-fun ButtonLight(text: String, onClick: () -> Unit) {
+fun ButtonLight(modifier: Modifier = Modifier, text: String, onClick: () -> Unit) {
     OutlinedButton(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(BUTTON_HEIGHT.dp),
+        modifier = modifier.then(
+            Modifier
+                .fillMaxWidth()
+                .height(BUTTON_HEIGHT.dp)
+        ),
         onClick = onClick,
         colors = ButtonDefaults.textButtonColors(
             backgroundColor = MaterialTheme.colors.primary,

--- a/app/src/main/java/com/rokt/roktdemo/ui/demo/error/GeneralError.kt
+++ b/app/src/main/java/com/rokt/roktdemo/ui/demo/error/GeneralError.kt
@@ -23,10 +23,10 @@ import com.rokt.roktdemo.ui.state.RoktDemoErrorTypes
 
 @Composable
 fun RoktError(errorType: RoktDemoErrorTypes?) {
-    if (errorType == RoktDemoErrorTypes.NETWORK) {
-        NetworkError()
-    } else {
-        GeneralError()
+    when (errorType) {
+        RoktDemoErrorTypes.NETWORK -> NetworkError()
+        RoktDemoErrorTypes.QRCODE -> QrCodeError()
+        else -> GeneralError()
     }
 }
 
@@ -81,6 +81,36 @@ private fun NetworkError() {
             )
             XSmallSpace()
             Title(stringResource(R.string.network_error_title_text), textAlign = TextAlign.Center)
+        }
+    }
+}
+
+@Composable
+private fun QrCodeError() {
+    Box(
+        Modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        RoktBackground()
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_error),
+                contentDescription = stringResource(R.string.content_description_error_icon)
+            )
+            XSmallSpace()
+            Title(stringResource(R.string.error_qr_code_title), textAlign = TextAlign.Center)
+            XSmallSpace()
+            ContentText(
+                text = stringResource(R.string.error_qr_code_message),
+                textAlign = TextAlign.Center
+            )
         }
     }
 }

--- a/app/src/main/java/com/rokt/roktdemo/ui/home/HomePage.kt
+++ b/app/src/main/java/com/rokt/roktdemo/ui/home/HomePage.kt
@@ -113,6 +113,11 @@ private fun HomeButtons(viewModel: HomeViewModel, actions: MainActions) {
             onClick = actions.demoLibraryClicked
         )
         DefaultSpace()
+        ButtonDark(
+            text = stringResource(id = R.string.menu_button_layouts_demo),
+            onClick = actions.demoLayoutsClicked
+        )
+        DefaultSpace()
         ButtonLight(
             text = stringResource(R.string.menu_button_about),
             onClick = actions.aboutRoktClicked

--- a/app/src/main/java/com/rokt/roktdemo/ui/layouts/DemoLayoutsPage.kt
+++ b/app/src/main/java/com/rokt/roktdemo/ui/layouts/DemoLayoutsPage.kt
@@ -1,0 +1,141 @@
+package com.rokt.roktdemo.ui.layouts
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.PlainTooltipBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
+import com.rokt.roktdemo.MainActivityViewModel
+import com.rokt.roktdemo.R
+import com.rokt.roktdemo.ui.common.BackButton
+import com.rokt.roktdemo.ui.common.ButtonDark
+import com.rokt.roktdemo.ui.common.ButtonLight
+import com.rokt.roktdemo.ui.common.Heading
+import com.rokt.roktdemo.ui.common.LoadingPage
+import com.rokt.roktdemo.ui.common.RoktEmbeddedWidget
+import com.rokt.roktdemo.ui.common.SmallSpace
+import com.rokt.roktdemo.ui.demo.error.RoktError
+import com.rokt.roktsdk.Widget
+import java.lang.ref.WeakReference
+
+private const val HEADER_TOP_PADDING = 50 // How far from the top the header items sit
+
+private var embeddedWidget: WeakReference<Widget>? = null
+
+@Composable
+fun DemoLayoutsPage(
+    backPressed: () -> Unit,
+    mainActivityViewModel: MainActivityViewModel,
+    viewModel: ScanQrViewModel = hiltViewModel()
+) {
+    val state = viewModel.state.collectAsState()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White, RectangleShape)
+    ) {
+
+        when {
+            state.value.loading -> {
+                LoadingPage()
+            }
+
+            state.value.hasData -> {
+                ScannerContent(
+                    backPressed = backPressed,
+                    viewModel = viewModel,
+                    state = requireNotNull(state.value.data)
+                )
+                state.value.data?.scannedData?.tagId?.let {
+                    mainActivityViewModel.updateSelectedTagId(it)
+                }
+            }
+
+            else -> {
+                RoktError(errorType = state.value.error)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScannerContent(
+    backPressed: () -> Unit,
+    viewModel: ScanQrViewModel,
+    state: ScanQrState,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+    ) {
+        Box(Modifier.padding(PaddingValues(start = 3.dp, top = HEADER_TOP_PADDING.dp))) {
+            BackButton(backPressed, MaterialTheme.colors.primaryVariant)
+        }
+        Column(
+            modifier = Modifier
+                .padding(30.dp)
+        ) {
+            Heading(text = stringResource(id = R.string.menu_button_layouts_demo))
+            ScannerView(viewModel = viewModel)
+            if (state.scannedData != null) {
+                SmallSpace()
+                ButtonDark(text = stringResource(id = R.string.button_execute)) {
+                    viewModel.executePreview(embeddedWidget)
+                }
+                SmallSpace()
+                RoktEmbeddedWidget(onWidgetAdded = { embeddedWidget = it })
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ScannerView(viewModel: ScanQrViewModel) {
+    val qrCodeIntentLauncher = rememberLauncherForActivityResult(
+        contract = ScanContract(),
+        onResult = { success ->
+            viewModel.qrCodeScanned(success, embeddedWidget)
+        }
+    )
+    val scanPrompt = stringResource(id = R.string.text_scan_prompt)
+    PlainTooltipBox(
+        tooltip = {
+            Text(
+                text = stringResource(id = R.string.text_scan_description),
+                color = MaterialTheme.colors.surface
+            )
+        }
+    ) {
+        ButtonLight(
+            modifier = Modifier.tooltipAnchor(),
+            text = stringResource(id = R.string.button_scan)
+        ) {
+            qrCodeIntentLauncher.launch(
+                ScanOptions().apply {
+                    setPrompt(scanPrompt)
+                    setBeepEnabled(true)
+                    setOrientationLocked(true)
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/rokt/roktdemo/ui/layouts/ScanQrViewModel.kt
+++ b/app/src/main/java/com/rokt/roktdemo/ui/layouts/ScanQrViewModel.kt
@@ -1,0 +1,78 @@
+package com.rokt.roktdemo.ui.layouts
+
+import androidx.lifecycle.ViewModel
+import com.google.gson.Gson
+import com.journeyapps.barcodescanner.ScanIntentResult
+import com.rokt.roktdemo.ui.demo.RoktExecutor
+import com.rokt.roktdemo.ui.layouts.model.PreviewData
+import com.rokt.roktdemo.ui.state.RoktDemoErrorTypes
+import com.rokt.roktdemo.ui.state.UiState
+import com.rokt.roktsdk.Widget
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import timber.log.Timber
+import java.lang.ref.WeakReference
+import java.util.Timer
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import kotlin.concurrent.timerTask
+
+@HiltViewModel
+class ScanQrViewModel @Inject constructor(
+    private val roktExecutor: RoktExecutor
+) : ViewModel() {
+
+    private val _state: MutableStateFlow<UiState<ScanQrState>> =
+        MutableStateFlow(UiState(loading = true))
+    val state: StateFlow<UiState<ScanQrState>>
+        get() = _state
+
+    init {
+        _state.value = UiState(data = ScanQrState(true))
+    }
+
+    fun qrCodeScanned(success: ScanIntentResult?, embeddedWidget: WeakReference<Widget>?) {
+        if (success == null) {
+            _state.update { UiState(data = ScanQrState(false)) }
+        } else {
+            try {
+                val qrData = Gson().fromJson(success.contents, PreviewData::class.java)
+                Timber.d(success.contents)
+                _state.update { UiState(data = ScanQrState(scannedData = qrData)) }
+                Timer().schedule(
+                    timerTask { executePreview(embeddedWidget) },
+                    TimeUnit.SECONDS.toMillis(EXECUTE_DELAY_SECONDS)
+                )
+            } catch (e: Exception) {
+                Timber.d(e, "Scan QR code error")
+                _state.update { UiState(error = RoktDemoErrorTypes.QRCODE) }
+            }
+        }
+    }
+
+    fun executePreview(embeddedWidget: WeakReference<Widget>?) {
+        val scannedData = _state.value.data?.scannedData
+        scannedData?.let { data ->
+            val attributes = hashMapOf(
+                ATTRIBUTE_IS_DEMO to true.toString(),
+                ATTRIBUTE_LAYOUT_ID to data.previewId,
+                ATTRIBUTE_CREATIVE_ID to data.creativeIds.joinToString(separator = ",")
+            )
+            val placeholders = embeddedWidget?.let { hashMapOf(PREVIEW_PLACEHOLDER to it) }
+            roktExecutor.executeRokt("", attributes, placeholders)
+        }
+    }
+}
+
+data class ScanQrState(
+    val scanning: Boolean = true,
+    val scannedData: PreviewData? = null
+)
+
+private const val ATTRIBUTE_IS_DEMO = "isDemo"
+private const val ATTRIBUTE_LAYOUT_ID = "layoutId"
+private const val ATTRIBUTE_CREATIVE_ID = "creativeId"
+private const val PREVIEW_PLACEHOLDER = "#rokt-placeholder"
+private const val EXECUTE_DELAY_SECONDS = 3L

--- a/app/src/main/java/com/rokt/roktdemo/ui/layouts/model/PreviewData.kt
+++ b/app/src/main/java/com/rokt/roktdemo/ui/layouts/model/PreviewData.kt
@@ -1,0 +1,8 @@
+package com.rokt.roktdemo.ui.layouts.model
+
+data class PreviewData(
+    val tagId: String,
+    val previewId: String,
+    val versionId: String,
+    val creativeIds: List<String>,
+)

--- a/app/src/main/java/com/rokt/roktdemo/ui/state/UiState.kt
+++ b/app/src/main/java/com/rokt/roktdemo/ui/state/UiState.kt
@@ -13,5 +13,5 @@ data class UiState<T>(
 }
 
 enum class RoktDemoErrorTypes {
-    GENERAL, NETWORK
+    GENERAL, NETWORK, QRCODE
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">Rokt</string>
     <string name="menu_button_demo">Placement library</string>
+    <string name="menu_button_layouts_demo">Layout library</string>
     <string name="menu_button_about">About this app</string>
     <string name="menu_button_contact">Contact us</string>
     <string name="footer_copyright">© Rokt 2023 - All rights reserved</string>
@@ -101,5 +102,11 @@
     <string name="text_increase_your_changes">Increase your changes of selling with access to up to 11 million Aussies each month.</string>
     <string name="text_limited_items"><![CDATA[*Limited to 2 items per month. T&C’s Apply.]]></string>
     <string name="text_ebay">ebay logo</string>
+    <string name="button_scan">Scan new Layout</string>
+    <string name="text_scan_description">Scan the QR code shown on the OnePlatform Layouts editor</string>
+    <string name="text_scan_prompt">Scan Rokt preview QR code</string>
+    <string name="button_execute">Refresh preview</string>
+    <string name="error_qr_code_title">Invalid QR code data.</string>
+    <string name="error_qr_code_message">Please scan the correct QR code from the One Platform layouts preview page. If the issue persists please contact us at www.rokt.com or try again later.</string>
 
 </resources>

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -7,10 +7,11 @@ object Versions {
 object Libs {
     const val androidGradlePlugin = "com.android.tools.build:gradle:8.0.2"
     const val googleMaterial = "com.google.android.material:material:1.3.0"
-    const val rokt = "com.rokt:roktsdk:4.0.0-alpha.1"
+    const val rokt = "com.rokt:roktsdk:4.0.0-alpha.3"
     const val timber = "com.jakewharton.timber:timber:4.7.1"
     const val okhttp = "com.squareup.okhttp3:okhttp:4.9.0"
     const val coil = "io.coil-kt:coil:1.2.2"
+    const val zxing = "com.journeyapps:zxing-android-embedded:4.3.0"
 
     object Retrofit {
         const val retrofit = "com.squareup.retrofit2:retrofit:1.6.0"
@@ -55,6 +56,7 @@ object Libs {
             const val uiUtil = "androidx.compose.ui:ui-util:1.4.3"
             const val runtime = "androidx.compose.runtime:runtime:$version"
             const val material = "androidx.compose.material:material:1.4.3"
+            const val material3 = "androidx.compose.material3:material3:1.1.1"
             const val animation = "androidx.compose.animation:animation:$version"
             const val tooling = "androidx.compose.ui:ui-tooling:1.4.3"
             const val navigation = "androidx.navigation:navigation-compose:1.0.0-alpha08"


### PR DESCRIPTION
### Background ###

Layout preview in the demo app

Fixes [MP-2428](https://rokt.atlassian.net/browse/MP-2428)

### What Has Changed: ###

* Implement new `Layout library` page
* Integrate `zxing` library for scanning QR code from OnePlatform preview page
* Extract the data from QR code and call `Rokt.init` using the tagId
* Call `Rokt.execute` with the attributes from the QR and preview the layout

### How Has This Been Tested? ###

Describe the tests that you ran to verify your changes. 

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.