### PR TITLE
NoJira - Fix the pipeline not injecting version number and code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,8 @@ android {
         applicationId "com.rokt.roktdemo"
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode 28
-        versionName "4.0.0"
+        versionCode findProperty("version_code") as Integer ?: 28
+        versionName findProperty("version_name") ?: "4.0.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,8 +49,8 @@ platform :android do
         task: 'assemble',
         build_type: 'Release',
         properties: {
-            "android.injected.version.code" => build_number,
-            "android.injected.version.name" => "BUILD_#{build_number}",
+            "version_code" => build_number,
+            "version_name" => "BUILD_#{build_number}",
           }
         )
     appcenter_upload(


### PR DESCRIPTION
### Background ###

New gradle plugin is not supporting injecting `android.injected.version.code` and `android.injected.version.name` through gradle project properties arguments. https://github.com/fastlane/fastlane/issues/20458
Inject the version and code manually and update them if present.

### What Has Changed: ###

Fix in the buildkite pipeline

### How Has This Been Tested? ###

Tested locally

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.