### PR TITLE
MP-3286 - Enable minify in release builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             signingConfig signingConfigs.release
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-dontwarn coil.request.ImageResult$Metadata
+-keep class com.rokt.roktdemo.model.* {
+     <fields>;
+ }

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -7,14 +7,14 @@ object Versions {
 object Libs {
     const val androidGradlePlugin = "com.android.tools.build:gradle:8.0.2"
     const val googleMaterial = "com.google.android.material:material:1.3.0"
-    const val rokt = "com.rokt:roktsdk:4.1.0-beta.1"
+    const val rokt = "com.rokt:roktsdk:4.2.0"
     const val timber = "com.jakewharton.timber:timber:4.7.1"
     const val okhttp = "com.squareup.okhttp3:okhttp:4.9.0"
     const val coil = "io.coil-kt:coil:1.2.2"
     const val zxing = "com.journeyapps:zxing-android-embedded:4.3.0"
 
     object Retrofit {
-        const val retrofit = "com.squareup.retrofit2:retrofit:1.6.0"
+        const val retrofit = "com.squareup.retrofit2:retrofit:2.9.0"
         const val gsonConverter = "com.squareup.retrofit2:converter-gson:2.9.0"
 
     }


### PR DESCRIPTION
### Background ###

* Enable minify in release variant
* Add proguard rules to keep the model classes and fields
* Update retrofit library to the latest version
* Update Rokt library to `4.2.0` with the proguard rules fix

Fixes [MP-3286](https://rokt.atlassian.net/browse/MP-3286)

### What Has Changed: ###

Enable minify in release builds

### How Has This Been Tested? ###

Tested locally

### Notes

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.