### PR TITLE
MP-3282 - Fix the issue when color mode change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,8 +4,9 @@
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />
+
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:name=".RoktDemoApplication"
@@ -18,6 +19,7 @@
         android:usesCleartextTraffic="true">
         <activity
             android:name=".MainActivity"
+            android:configChanges="orientation|screenSize|uiMode"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
### Background ###

Add `android:configChanges` flags.
This will prevent the activity from recreating and calling the init and execute again

Fixes ﻿﻿[MP-3282](https://rokt.atlassian.net/browse/MP-3282)

### What Has Changed: ###

Add the Activity config change flags

### How Has This Been Tested? ###

Tested locally.

### Notes

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.