### PR TITLE
NoJira - Enable layout preview by sending preview info as JSON using intent extra and custom URI

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,12 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="rokt" android:host="demo" android:path="/preview" />
+            </intent-filter>
         </activity>
 
         <meta-data

--- a/app/src/main/java/com/rokt/roktdemo/MainActivity.kt
+++ b/app/src/main/java/com/rokt/roktdemo/MainActivity.kt
@@ -11,12 +11,18 @@ import com.rokt.roktsdk.Rokt
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 
+private const val PREVIEW_PARAM_EXTRA = "preview"
+private const val URI_QUERY_PARAM = "config"
+
 @AndroidEntryPoint
 class MainActivity : androidx.activity.ComponentActivity() {
     private val viewModel: MainActivityViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        intent.getStringExtra(PREVIEW_PARAM_EXTRA)?.let(viewModel::updatePreviewParameter)
+        intent.data?.getQueryParameter(URI_QUERY_PARAM)?.let(viewModel::updatePreviewParameter)
 
         viewModel.selectedTagId.observe(this) {
             Timber.d("Calling Rokt.Init with new tag Id: $it")

--- a/app/src/main/java/com/rokt/roktdemo/MainActivityViewModel.kt
+++ b/app/src/main/java/com/rokt/roktdemo/MainActivityViewModel.kt
@@ -1,5 +1,6 @@
 package com.rokt.roktdemo
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.distinctUntilChanged
@@ -15,6 +16,8 @@ class MainActivityViewModel @Inject constructor(settingsRepository: SettingsRepo
     private val _selectedTagId = MutableLiveData<String>()
     val selectedTagId = _selectedTagId.distinctUntilChanged()
 
+    val previewParameterString = mutableStateOf<String?>(null)
+
     init {
         if (settingsRepository.getBooleanSettingsValue(STAGE_ENV_ENABLED)) {
             Rokt.setEnvironment(Rokt.Environment.Stage)
@@ -26,5 +29,9 @@ class MainActivityViewModel @Inject constructor(settingsRepository: SettingsRepo
 
     fun updateSelectedTagId(tagId: String) {
         _selectedTagId.value = tagId
+    }
+
+    fun updatePreviewParameter(intentData: String) {
+        previewParameterString.value = intentData
     }
 }

--- a/app/src/main/java/com/rokt/roktdemo/ui/RoktDemoApp.kt
+++ b/app/src/main/java/com/rokt/roktdemo/ui/RoktDemoApp.kt
@@ -43,6 +43,9 @@ fun RoktDemoApp(viewModel: MainActivityViewModel) {
                     SettingsPage(actions.backPressed)
                 }
             }
+            viewModel.previewParameterString.value?.let {
+                actions.demoLayoutsClicked()
+            }
         }
     }
 }


### PR DESCRIPTION
### Background ###

* Handle string intent extra with the key `preview`
* Handle custom URI scheme with `rokt://`, host name `demo` and path `/preview`
* Get the query parameter `config` from the URI and decode the preview JSON string.
* Navigate to the Layout preview page and trigger the preview with the received JSON string

### What Has Changed: ###

Adding preview functionality shortcuts

### How Has This Been Tested? ###

**Intent extra**
```shell
adb shell am start -n  com.rokt.roktdemo/com.rokt.roktdemo.MainActivity --es preview "\{\"tagId\":\"3235956756924911616\",\"previewId\":\"3347565182159552540\",\"versionId\":\"1726100556091\",\"creativeIds\":[\"3335250570341581807\",\"3334286925719734182\",\"3341268103002062853\",\"3341270564018389003\"],\"language\":\"en\",\"layoutVariantIds\":[\"3347565182159552541\",\"3347565182159552542\"]\}"
```

Custom URI
```shell
adb shell am start -a android.intent.action.VIEW -d "rokt://demo/preview?config=\{\"tagId\":\"3198447216177237634\",\"previewId\":\"3344967079132791093\",\"versionId\":\"1725495638770\",\"creativeIds\":[\"3335250570341581807\",\"3334286925719734182\",\"3334226469759813591\",\"3334247566639236821\"],\"language\":\"en\",\"layoutVariantIds\":[\"3344967079132791094\",\"3344967079132791095\"]\}"
```

https://github.com/user-attachments/assets/4e2b003e-72ac-4960-b381-8e3148970589


### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.