### PR TITLE
LAYOUT-1519 - Use RoktUx library in Demo app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,6 +95,8 @@ dependencies {
     // Rokt
     implementation Libs.rokt
     implementation Libs.timber
+    implementation Libs.roktUx
+    implementation Libs.roktNetworkHelper
 
     // Hilt
     implementation Libs.Hilt.android

--- a/app/src/main/java/com/rokt/roktdemo/ui/layouts/ScanQrViewModel.kt
+++ b/app/src/main/java/com/rokt/roktdemo/ui/layouts/ScanQrViewModel.kt
@@ -1,7 +1,10 @@
 package com.rokt.roktdemo.ui.layouts
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.google.gson.Gson
+import com.rokt.networkhelper.data.RoktNetwork
 import com.rokt.roktdemo.ui.demo.RoktExecutor
 import com.rokt.roktdemo.ui.layouts.model.DemoLayoutConfig
 import com.rokt.roktdemo.ui.layouts.model.DemoLayoutSlotConfig
@@ -9,11 +12,13 @@ import com.rokt.roktdemo.ui.layouts.model.DemoModeConfig
 import com.rokt.roktdemo.ui.layouts.model.PreviewData
 import com.rokt.roktdemo.ui.state.RoktDemoErrorTypes
 import com.rokt.roktdemo.ui.state.UiState
+import com.rokt.roktsdk.BuildConfig
 import com.rokt.roktsdk.Widget
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.lang.ref.WeakReference
 import java.util.HashMap
@@ -33,21 +38,24 @@ class ScanQrViewModel @Inject constructor(
         get() = _state
 
     init {
-        _state.value = UiState(data = ScanQrState(true))
+        _state.value = UiState(data = ScanQrState())
     }
 
-    fun qrCodeScanned(rawData: String?, embeddedWidget: WeakReference<Widget>?) {
+    fun qrCodeScanned(rawData: String?) {
         if (rawData == null) {
-            _state.update { UiState(data = ScanQrState(false)) }
+            _state.update { UiState(data = ScanQrState()) }
         } else {
             try {
                 val qrData = Gson().fromJson(rawData, PreviewData::class.java)
                 Timber.d(rawData)
-                _state.update { UiState(data = ScanQrState(scannedData = qrData)) }
-                Timer().schedule(
-                    timerTask { executePreview(embeddedWidget) },
-                    TimeUnit.SECONDS.toMillis(EXECUTE_DELAY_SECONDS)
-                )
+                _state.update {
+                    UiState(
+                        data = ScanQrState(
+                            scannedData = qrData,
+                            previewState = PreviewState.ScannedState(qrData)
+                        )
+                    )
+                }
             } catch (e: Exception) {
                 Timber.d(e, "Scan QR code error")
                 _state.update { UiState(error = RoktDemoErrorTypes.QRCODE) }
@@ -55,17 +63,60 @@ class ScanQrViewModel @Inject constructor(
         }
     }
 
+    fun legacySdkSelected(embeddedWidget: WeakReference<Widget>?) {
+        Timer().schedule(
+            timerTask { executePreview(embeddedWidget) },
+            TimeUnit.SECONDS.toMillis(EXECUTE_DELAY_SECONDS)
+        )
+    }
+
+    fun uxHelperSdkSelected(context: Context) {
+        viewModelScope.launch {
+            _state.value.data?.scannedData?.let { data ->
+                RoktNetwork.init(data.tagId, BuildConfig.VERSION_NAME, context)
+                RoktNetwork.experience("", buildAttributes(data))
+                    .onSuccess { response ->
+                        Timber.d(response)
+                        _state.update {
+                            it.copy(
+                                data = _state.value.data!!.copy(
+                                    previewState = PreviewState.UxHelperSdkData(
+                                        response
+                                    )
+                                )
+                            )
+                        }
+                    }
+                    .onFailure { Timber.e(it) }
+            }
+        }
+
+    }
+
     fun executePreview(embeddedWidget: WeakReference<Widget>?) {
         val scannedData = _state.value.data?.scannedData
         scannedData?.let { data ->
-            val attributes = buildMap {
-                this[ATTRIBUTE_IS_DEMO] = true.toString()
-                data.language?.let { this[ATTRIBUTE_LANGUAGE] = it }
-                getDemoConfig(data)?.let { this[ATTRIBUTE_DEMO_CONFIG] = it }
-            }
+            val attributes = buildAttributes(data)
             val placeholders = embeddedWidget?.let { hashMapOf(PREVIEW_PLACEHOLDER to it) }
             roktExecutor.executeRokt("", HashMap(attributes), placeholders)
+            _state.update {
+                it.copy(
+                    data = _state.value.data!!.copy(
+                        previewState = PreviewState.LegacySdkData(
+                            data.tagId
+                        )
+                    )
+                )
+            }
         }
+    }
+
+    private fun buildAttributes(data: PreviewData): Map<String, String> {
+        val attributes = mutableMapOf<String, String>()
+        attributes[ATTRIBUTE_IS_DEMO] = true.toString()
+        data.language?.let { attributes[ATTRIBUTE_LANGUAGE] = it }
+        getDemoConfig(data)?.let { attributes[ATTRIBUTE_DEMO_CONFIG] = it }
+        return attributes
     }
 }
 
@@ -95,9 +146,15 @@ private fun getDemoConfig(previewData: PreviewData): String? {
 }
 
 data class ScanQrState(
-    val scanning: Boolean = true,
-    val scannedData: PreviewData? = null
+    val scannedData: PreviewData? = null,
+    val previewState: PreviewState? = null,
 )
+
+sealed class PreviewState {
+    data class ScannedState(val data: PreviewData) : PreviewState()
+    data class LegacySdkData(val tagId: String) : PreviewState()
+    data class UxHelperSdkData(val response: String) : PreviewState()
+}
 
 private const val ATTRIBUTE_IS_DEMO = "isDemo"
 private const val ATTRIBUTE_LANGUAGE = "rokt.language"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,4 +111,8 @@
     <string name="error_qr_code_message">Please scan the correct QR code from the One Platform layouts preview page. If the issue persists please contact us at www.rokt.com or try again later.</string>
     <string name="settings_stage_env">Stage environment</string>
     <string name="settings_debug_logs">Enable debug logs</string>
+    <string name="button_uxhelper">UX Helper SDK</string>
+    <string name="button_legacysdk">Legacy SDK</string>
+    <string name="text_select_sdk_title">Select SDK</string>
+    <string name="text_select_sdk_description">Select which SDK to be used for rendering the preview</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ allprojects {
     repositories {
         google()
 
+        mavenLocal()
+
         // Rokt SDK artifacts
         maven {
             url "https://apps.rokt.com/msdk"

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -7,7 +7,9 @@ object Versions {
 object Libs {
     const val androidGradlePlugin = "com.android.tools.build:gradle:8.0.2"
     const val googleMaterial = "com.google.android.material:material:1.3.0"
-    const val rokt = "com.rokt:roktsdk:4.6.0-alpha.3"
+    const val rokt = "com.rokt:roktsdk:4.6.0"
+    const val roktUx = "com.rokt:roktux:0.0.1"
+    const val roktNetworkHelper = "com.rokt:networkhelper:0.0.1"
     const val timber = "com.jakewharton.timber:timber:4.7.1"
     const val okhttp = "com.squareup.okhttp3:okhttp:4.9.0"
     const val coil = "io.coil-kt:coil-compose:2.2.0"


### PR DESCRIPTION
### Background ###

* Add the mavenLocal for locally published libraries
* Use the `roktux` and `networkhelper` libraries
* Show a dialog after the QR code is scanned, to choose which should be used for rendering
* When legacy sdk is selected, follow the old flow, call init and trigger execute
* When UxHelper is selected use networkhelper to fetch the demo response as a string and feed it to `RoktLayout` composable to render

Fixes [(issue)]

### What Has Changed: ###

List out what has changed as a result of this PR.

### How Has This Been Tested? ###

Describe the tests that you ran to verify your changes. 

### Notes

Add any notes or extra information here that might be useful to the reviewer if applicable i.e. links to documentation/blogs or dashboards.

### Checklist: ###

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.