### PR TITLE
ci(actions): add dependabot and fix firebase release notes

### DIFF
--- a/.github/actions/upload-apk/action.yml
+++ b/.github/actions/upload-apk/action.yml
@@ -41,22 +41,28 @@ runs:
         service_account: ${{ inputs.service_account }}
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
 
-    - name: Set release notes
+    - name: Write release notes file
       id: release-notes
       shell: bash
+      env:
+        INPUT_RELEASE_NOTES: ${{ inputs.release_notes }}
       run: |
-        if [ -n "${{ inputs.release_notes }}" ]; then
-          echo "release_text=${{ inputs.release_notes }}" >> $GITHUB_OUTPUT
+        release_notes_file=$(mktemp)
+
+        if [ -n "$INPUT_RELEASE_NOTES" ]; then
+          printf '%s\n' "$INPUT_RELEASE_NOTES" > "$release_notes_file"
         else
           version_name=$(grep "version_name=" gradle.properties | cut -d'=' -f2)
-          echo "release_text=Version $version_name" >> $GITHUB_OUTPUT
+          printf 'Version %s\n' "$version_name" > "$release_notes_file"
         fi
+
+        echo "release_notes_file=$release_notes_file" >> "$GITHUB_OUTPUT"
 
     - name: Upload APK
       shell: bash
       run: |
         firebase appdistribution:distribute \
-          --app '${{ inputs.firebase_app_id }}' \
-          ${{ inputs.apk_path }} \
-          --groups '${{ inputs.testing_groups }}' \
-          --release-notes '${{ steps.release-notes.outputs.release_text }}'
+          --app "${{ inputs.firebase_app_id }}" \
+          "${{ inputs.apk_path }}" \
+          --groups "${{ inputs.testing_groups }}" \
+          --release-notes-file "${{ steps.release-notes.outputs.release_notes_file }}"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - dependabot
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - dependabot
+
+  - package-ecosystem: github-actions
+    directory: /.github/actions/setup-java
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - dependabot
+
+  - package-ecosystem: github-actions
+    directory: /.github/actions/build-apk
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - dependabot
+
+  - package-ecosystem: github-actions
+    directory: /.github/actions/upload-apk
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2
+    labels:
+      - dependabot

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -56,11 +56,11 @@ jobs:
       - name: Get release notes
         id: release-notes
         run: |
-          # Get the commit message of the last merge
-          RELEASE_NOTES=$(git log -1 --pretty=%B)
-          # Escape newlines and quotes for JSON
-          RELEASE_NOTES=$(echo "$RELEASE_NOTES" | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/"/\\"/g')
-          echo "release_notes=$RELEASE_NOTES" >> $GITHUB_OUTPUT
+          {
+            echo "release_notes<<EOF"
+            git log -1 --pretty=%B
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Upload APK
         uses: ./.github/actions/upload-apk
@@ -70,7 +70,10 @@ jobs:
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           firebase_app_id: ${{ secrets.FIREBASE_APP_ID }}
           testing_groups: ${{ secrets.TESTING_GROUPS }}
-          release_notes: SDK Version ${{ steps.version-name.outputs.version_name }} \n ${{ steps.release-notes.outputs.release_notes }}
+          release_notes: |
+            SDK Version ${{ steps.version-name.outputs.version_name }}
+
+            ${{ steps.release-notes.outputs.release_notes }}
 
       - name: Create Github release
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0


### PR DESCRIPTION
### Background ###

This pull request adds Dependabot coverage for the repo Gradle and GitHub Actions dependencies, and fixes a quoting bug in the release workflow that caused Firebase distribution to fail when release notes contained multiline text or apostrophes.

Fixes N/A

### What Has Changed: ###

- add a new Dependabot config with weekly updates for Gradle, root GitHub workflows, and composite actions under the .github/actions directory
- update the upload composite action to write release notes to a temp file and pass them to Firebase using the release notes file option
- update the release-from-main workflow to emit real multiline release notes via GITHUB_OUTPUT and pass them as a YAML block scalar

### How Has This Been Tested? ###

- parsed the updated workflow YAML files locally
- ran a local shell check with multiline release notes containing an apostrophe to verify the new file based path handles it safely

### Notes

- the Dependabot config follows the same weekly labeled pattern used in the referenced ROKT repos, with extra GitHub Actions entries for the composite action directories in this repo

### Checklist: ###

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.