### PR TITLE
fix: pin GitHub Actions to commit SHAs for supply chain security

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -11,6 +11,6 @@ permissions:
 jobs:
   pr-notifiy:
     name: "Notify GChat"
-    uses: ROKT/rokt-workflows/.github/workflows/oss_pr_opened_notification.yml@main
+    uses: ROKT/rokt-workflows/.github/workflows/oss_pr_opened_notification.yml@1859338d7c2c2b873233505c751acbf09fb218d5 # main
     secrets:
       gchat_webhook: ${{ secrets.GCHAT_PRS_WEBHOOK }}


### PR DESCRIPTION
## Summary
- Pin third-party GitHub Actions to full commit SHAs
- Addresses **1 unpinned-uses** findings from zizmor security audit

## Rollback plan
Revert this PR.