### PR TITLE
fix: harden GitHub Actions workflows and add zizmor CI check

### DIFF
--- a/.github/workflows/distribute-to-firebase.yml
+++ b/.github/workflows/distribute-to-firebase.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Build APK
         uses: ./.github/actions/build-apk
@@ -37,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Download APK artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup JDK
         uses: ./.github/actions/setup-java
@@ -28,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup JDK
         uses: ./.github/actions/setup-java
@@ -45,6 +49,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup JDK
         uses: ./.github/actions/setup-java

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Build APK
         uses: ./.github/actions/build-apk
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Download APK artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/trigger-snapshot-to-firebase.yml
+++ b/.github/workflows/trigger-snapshot-to-firebase.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Update version
         run: |
@@ -52,6 +54,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Download APK artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,39 @@
+name: Zizmor Security Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Scan GitHub Actions workflows
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+      # TODO: Remove continue-on-error once pre-existing findings are triaged.
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        continue-on-error: true
+        with:
+          advanced-security: false


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to 9 checkout steps across 4 workflows (prevents credential leakage via artifacts)
- Add `zizmor.yml` CI workflow using `zizmor-action` for inline PR annotations:
  - Pinned to zizmor-action v0.5.2
  - Pinned to ubuntu-24.04 runner, `fetch-depth: 1`
  - `advanced-security: false` (private repo)
  - Uses `continue-on-error: true` (informational — reports findings without blocking PRs)
  - `timeout-minutes: 5`, includes `workflow_dispatch` for manual runs

**Checkout audit:** All 9 checkout steps verified safe — no downstream git-write operations.

**Intentionally not changed:**
- `trigger-release-to-firebase.yml` — uses `peter-evans/create-pull-request`, needs git credentials

**Permissions unchanged** — existing workflow-level permissions left as-is.

## Test plan
- [x] Verify CI/CD pipelines run successfully
- [ ] Confirm zizmor workflow runs after merge (new workflow — only triggers once merged to main)

## Rollback plan
Revert this PR.