### PR TITLE
chore: update Rokt SDK to 6.0.1-rc.1

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -68,3 +68,26 @@ jobs:
         with:
           name: debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk
+
+  assemble-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Build APK
+        uses: ./.github/actions/build-apk
+        with:
+          store_password: ${{ secrets.ANDROID_STORE_PASSWORD }}
+          key_alias: ${{ secrets.ANDROID_KEY_ALIAS }}
+          key_password: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          google_services_json: ${{ secrets.GOOGLE_SERVICES_JSON }}
+          keystore_file: ${{ secrets.ANDROID_KEYSTORE_FILE }}
+
+      - name: Upload APK Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-apk
+          path: app/build/outputs/apk/release/app-release.apk

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The latest version of Android Studio is required. Follow [these instructions](ht
 
 `brew install --cask android-studio`  
 
-The project is configured to run on Android API 21 and above and compiled against API 31.
+The project is configured to run on Android API 23 and above and compiled against API 35.
 
 ## How to build and run Locally?
 1. Open Android Studio

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,6 +78,7 @@ dependencies {
 
     // Compose
     implementation Libs.AndroidX.Compose.material
+    implementation Libs.AndroidX.Compose.materialIconsExtended
     implementation Libs.AndroidX.Compose.material3
     implementation Libs.AndroidX.Activity.activityCompose
     implementation Libs.AndroidX.Compose.foundation

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-kapt'
+    id 'org.jetbrains.kotlin.plugin.compose'
     id 'dagger.hilt.android.plugin'
     id 'com.google.gms.google-services'
 }
@@ -25,7 +26,7 @@ android {
 
     defaultConfig {
         applicationId "com.rokt.roktdemo"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 35
         versionCode findProperty("version_code") as Integer ?: 47
         versionName findProperty("version_name") ?: "1.2.27"
@@ -52,9 +53,6 @@ android {
     }
     buildFeatures {
         compose true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion Libs.AndroidX.Compose.version
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_11

--- a/app/src/test/java/com/rokt/roktdemo/CoroutinesTestRule.kt
+++ b/app/src/test/java/com/rokt/roktdemo/CoroutinesTestRule.kt
@@ -3,17 +3,18 @@ package com.rokt.roktdemo
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
 @ExperimentalCoroutinesApi
 class CoroutineTestRule(
-    val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher(),
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
 ) : TestWatcher() {
 
     val testDispatcherProvider = object : DispatcherProvider {
@@ -31,7 +32,6 @@ class CoroutineTestRule(
     override fun finished(description: Description?) {
         super.finished(description)
         Dispatchers.resetMain()
-        testDispatcher.cleanupTestCoroutines()
     }
 }
 
@@ -43,6 +43,8 @@ interface DispatcherProvider {
 }
 
 @ExperimentalCoroutinesApi
-fun CoroutineTestRule.runBlockingTest(block: suspend TestCoroutineScope.() -> Unit) {
-    testDispatcher.runBlockingTest(block)
+fun TestDispatcher.runBlockingTest(block: suspend TestScope.() -> Unit) {
+    TestScope(this).runTest {
+        block()
+    }
 }

--- a/app/src/test/java/com/rokt/roktdemo/WalkthroughScreenViewModelTest.kt
+++ b/app/src/test/java/com/rokt/roktdemo/WalkthroughScreenViewModelTest.kt
@@ -4,7 +4,6 @@ import com.google.common.truth.Truth.assertThat
 import com.rokt.roktdemo.data.library.DemoLibraryRepositoryMockImpl
 import com.rokt.roktdemo.ui.demo.walkthrough.screen.WalkthroughScreenViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/com/rokt/roktdemo/checkout/AccountDetailsViewModelTest.kt
+++ b/app/src/test/java/com/rokt/roktdemo/checkout/AccountDetailsViewModelTest.kt
@@ -2,11 +2,11 @@ package com.rokt.roktdemo.checkout
 
 import com.google.common.truth.Truth
 import com.rokt.roktdemo.CoroutineTestRule
-import com.rokt.roktdemo.runBlockingTest
 import com.rokt.roktdemo.data.library.DemoLibraryRepositoryMockImpl
 import com.rokt.roktdemo.data.validate.ValidationState
 import com.rokt.roktdemo.data.validate.ValidationStatus
 import com.rokt.roktdemo.data.validate.ValidatorRepository
+import com.rokt.roktdemo.runBlockingTest
 import com.rokt.roktdemo.ui.demo.custom.screen.account.AccountDetailsViewModel
 import io.mockk.every
 import io.mockk.mockk

--- a/app/src/test/java/com/rokt/roktdemo/checkout/AccountDetailsViewModelTest.kt
+++ b/app/src/test/java/com/rokt/roktdemo/checkout/AccountDetailsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.rokt.roktdemo.checkout
 
 import com.google.common.truth.Truth
 import com.rokt.roktdemo.CoroutineTestRule
+import com.rokt.roktdemo.runBlockingTest
 import com.rokt.roktdemo.data.library.DemoLibraryRepositoryMockImpl
 import com.rokt.roktdemo.data.validate.ValidationState
 import com.rokt.roktdemo.data.validate.ValidationStatus
@@ -10,7 +11,6 @@ import com.rokt.roktdemo.ui.demo.custom.screen.account.AccountDetailsViewModel
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/test/java/com/rokt/roktdemo/checkout/CustomCheckoutViewModelTest.kt
+++ b/app/src/test/java/com/rokt/roktdemo/checkout/CustomCheckoutViewModelTest.kt
@@ -2,6 +2,7 @@ package com.rokt.roktdemo.checkout
 
 import com.google.common.truth.Truth
 import com.rokt.roktdemo.CoroutineTestRule
+import com.rokt.roktdemo.runBlockingTest
 import com.rokt.roktdemo.ui.demo.RoktExecutor
 import com.rokt.roktdemo.ui.demo.custom.CustomCheckoutViewModel
 import com.rokt.roktsdk.Widget
@@ -9,7 +10,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/test/java/com/rokt/roktdemo/checkout/CustomerDetailsViewmodelTest.kt
+++ b/app/src/test/java/com/rokt/roktdemo/checkout/CustomerDetailsViewmodelTest.kt
@@ -2,9 +2,9 @@ package com.rokt.roktdemo.checkout
 
 import com.google.common.truth.Truth
 import com.rokt.roktdemo.CoroutineTestRule
-import com.rokt.roktdemo.runBlockingTest
 import com.rokt.roktdemo.data.data
 import com.rokt.roktdemo.data.library.DemoLibraryRepositoryMockImpl
+import com.rokt.roktdemo.runBlockingTest
 import com.rokt.roktdemo.ui.demo.custom.screen.customer.CustomerDetailsViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect

--- a/app/src/test/java/com/rokt/roktdemo/checkout/CustomerDetailsViewmodelTest.kt
+++ b/app/src/test/java/com/rokt/roktdemo/checkout/CustomerDetailsViewmodelTest.kt
@@ -2,12 +2,12 @@ package com.rokt.roktdemo.checkout
 
 import com.google.common.truth.Truth
 import com.rokt.roktdemo.CoroutineTestRule
+import com.rokt.roktdemo.runBlockingTest
 import com.rokt.roktdemo.data.data
 import com.rokt.roktdemo.data.library.DemoLibraryRepositoryMockImpl
 import com.rokt.roktdemo.ui.demo.custom.screen.customer.CustomerDetailsViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
     dependencies {
         classpath Libs.androidGradlePlugin
         classpath Libs.Kotlin.gradlePlugin
+        classpath Libs.Kotlin.composeCompilerGradlePlugin
         classpath Libs.Hilt.gradlePlugin
         classpath Libs.Google.googleSerives
 
@@ -39,4 +40,3 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
-

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -7,7 +7,7 @@ object Versions {
 object Libs {
     const val androidGradlePlugin = "com.android.tools.build:gradle:8.6.0"
     const val googleMaterial = "com.google.android.material:material:1.3.0"
-    const val rokt = "com.rokt:roktsdk:5.0.0"
+    const val rokt = "com.rokt:roktsdk:6.0.0-rc.1"
     const val timber = "com.jakewharton.timber:timber:4.7.1"
     const val okhttp = "com.squareup.okhttp3:okhttp:4.9.0"
     const val coil = "io.coil-kt:coil-compose:2.2.0"
@@ -19,10 +19,12 @@ object Libs {
     }
 
     object Kotlin {
-        private const val version = "1.8.21"
+        private const val version = "2.1.20"
         const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$version"
         const val gradlePlugin =
             "org.jetbrains.kotlin:kotlin-gradle-plugin:$version"
+        const val composeCompilerGradlePlugin =
+            "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$version"
     }
 
     object Coroutines {

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -55,6 +55,7 @@ object Libs {
             const val uiUtil = "androidx.compose.ui:ui-util:1.4.3"
             const val runtime = "androidx.compose.runtime:runtime:$version"
             const val material = "androidx.compose.material:material:1.4.3"
+            const val materialIconsExtended = "androidx.compose.material:material-icons-extended:1.7.8"
             const val material3 = "androidx.compose.material3:material3:1.1.2"
             const val animation = "androidx.compose.animation:animation:$version"
             const val tooling = "androidx.compose.ui:ui-tooling:1.4.3"
@@ -72,7 +73,7 @@ object Libs {
     }
 
     object Hilt {
-        private const val version = "2.44.2"
+        private const val version = "2.57.2"
 
         const val gradlePlugin = "com.google.dagger:hilt-android-gradle-plugin:$version"
         const val android = "com.google.dagger:hilt-android:$version"

--- a/buildSrc/src/main/java/dependencies.kt
+++ b/buildSrc/src/main/java/dependencies.kt
@@ -7,7 +7,7 @@ object Versions {
 object Libs {
     const val androidGradlePlugin = "com.android.tools.build:gradle:8.6.0"
     const val googleMaterial = "com.google.android.material:material:1.3.0"
-    const val rokt = "com.rokt:roktsdk:6.0.0-rc.1"
+    const val rokt = "com.rokt:roktsdk:6.0.1-rc.1"
     const val timber = "com.jakewharton.timber:timber:4.7.1"
     const val okhttp = "com.squareup.okhttp3:okhttp:4.9.0"
     const val coil = "io.coil-kt:coil-compose:2.2.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 version_code=62
-version_name=5.0.0
+version_name=6.0.0-rc.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 version_code=62
-version_name=6.0.0-rc.1
+version_name=6.0.1-rc.1


### PR DESCRIPTION
### Background ###

Rokt SDK 6.0.1-rc.1 is released and this demo app should track that release candidate for validation.

### What Has Changed: ###

- Updated the Rokt SDK dependency to 6.0.1-rc.1.
- Updated app version_name to 6.0.1-rc.1.

### How Has This Been Tested? ###

- ./gradlew --no-daemon help

### Notes

No UI behavior changes in this update.

### Checklist: ###

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [ ] All insignificant commits have been squashed.